### PR TITLE
Add Data.HPB.AST to other-modules

### DIFF
--- a/hpb.cabal
+++ b/hpb.cabal
@@ -48,6 +48,7 @@ executable hpb
   ghc-prof-options: -fprof-auto-top -O2
 
   other-modules:
+    Data.HPB.AST
     Data.HPB.Lexer
     Data.HPB.Parser
     Data.HPB.Partial


### PR DESCRIPTION
This is necessary if you want `Data.HPB.AST` to be included in an `sdist` tarball. (Plus `stack` warns you about this.)