### PR TITLE
Add initial support for syntax keyword

### DIFF
--- a/hpb/Data/HPB/AST.hs
+++ b/hpb/Data/HPB/AST.hs
@@ -49,6 +49,10 @@ module Data.HPB.AST
   , nextLine
   , Posd(..)
   , failAt
+    -- * Syntax
+  , Syntax(..)
+  , Proto(..)
+  , stringAsSyntax
   ) where
 
 import Data.Maybe
@@ -512,3 +516,31 @@ instance Pretty Package where
     vcat (pretty <$> decls)
   pretty (Package Nothing decls) =
     vcat (pretty <$> decls)
+
+------------------------------------------------------------------------
+-- Syntax
+
+data Syntax = Proto2 | Proto3
+
+stringAsSyntax :: Monad m => String -> Posd StringLit -> m Syntax
+stringAsSyntax msg (Posd v p)
+  | str == "proto2" = return Proto2
+  | str == "proto3" = return Proto3
+  | otherwise       = failAt p msg
+  where str = stringText v
+
+instance Pretty Syntax where
+  pretty Proto2 = dquotes $ text "proto2"
+  pretty Proto3 = dquotes $ text "proto3"
+
+------------------------------------------------------------------------
+-- Proto
+
+data Proto = Proto (Maybe Syntax) Package
+
+instance Pretty Proto where
+  pretty (Proto (Just syn) pkg) =
+    text "syntax" <+> text "=" <+> pretty syn <> text ";" <$$>
+    pretty pkg
+  pretty (Proto Nothing pkg) =
+    pretty pkg

--- a/hpb/Data/HPB/Lexer.x
+++ b/hpb/Data/HPB/Lexer.x
@@ -57,6 +57,7 @@ $any = [. $newline]
   | "returns"
   | "rpc"
   | "service"
+  | "syntax"
   | "to"
   | "true"
 

--- a/hpb/Data/HPB/Resolver.hs
+++ b/hpb/Data/HPB/Resolver.hs
@@ -738,8 +738,8 @@ instance Pretty Package where
     text "" <$$>
     vcat (pretty <$> moduleDefs pkg)
 
-resolvePackage :: FilePath -> Maybe String -> A.Package -> Either String Package
-resolvePackage path mnm (A.Package pkg_nm decls) = runPartial $ do
+resolvePackage :: FilePath -> Maybe String -> A.Proto -> Either String Package
+resolvePackage path mnm (A.Proto syn (A.Package pkg_nm decls)) = runPartial $ do
   ctx <-
     flip execStateT emptyFileContext $ do
       mapM_ extractFileDecl decls

--- a/hpb/Main_hpb.hs
+++ b/hpb/Main_hpb.hs
@@ -164,7 +164,7 @@ printErrorAndExit msg = do
 exitOnError :: IOError -> IO a
 exitOnError e = printErrorAndExit (ioeGetErrorString e)
 
-loadAndParseFile :: FilePath -> IO A.Package
+loadAndParseFile :: FilePath -> IO A.Proto
 loadAndParseFile path = do
   mcontents <- try $ LazyBS.readFile path
   case mcontents of


### PR DESCRIPTION
### Work in progress, review requested

---

This PR addresses #1 and adds the `syntax` keyword. Valid values should include `proto2` and `proto3`.

Currently, the `syntax` keyword is lexed and parsed, with a minor caveat.

While the correct output is produced when `hpb -P` is called on a valid syntax value,
```
[nix-shell:~/dev/hpb]$ echo 'syntax = "proto3";' > valid.proto
[nix-shell:~/dev/hpb]$ hpb -P test.proto
syntax = "proto3";
```
invalid syntax values cause `hpb -P` to fail silently:
```
[nix-shell:~/dev/hpb]$ echo 'syntax = "invalid";' > invalid.proto
[nix-shell:~/dev/hpb]$ hpb -P invalid.proto
```
Expected output is `syntax must be "proto2" or "proto3"`.

I'm guessing the error lies somewhere around `hpb/Data/HPB/AST.hs:525`, but could use some help. I'd also appreciate any general criticism on coding style or idiomatic Haskell.