### PR TITLE
Add Semigroup instance to support multiple GHC versions.

### DIFF
--- a/hpb/Data/HPB/Resolver.hs
+++ b/hpb/Data/HPB/Resolver.hs
@@ -669,6 +669,13 @@ ppResolvedMessage m =
     indent 3 (vcatPrefix1 (text "  ") (text ", ") (ppFieldDecl <$> fields)) <>
     text "}" <$$>
     text "" <$$>
+
+    text "instance HPB.Semigroup" <+> pretty nm <+> text "where" <$$>
+    text "  (<>) x y =" <+> pretty nm <+> text "{" <$$>
+    indent 17 (vcatPrefix1 (text "  ") (text ", ") (ppFieldAppend "x" "y" <$> fields)) <>
+    text "}" <$$>
+    text "" <$$>
+
     text "instance HPB.Monoid" <+> pretty nm <+> text "where" <$$>
     text "  mempty =" <+> pretty nm <+> text "{" <$$>
     indent 12 (vcatPrefix1 (text "  ") (text ", ") (ppFieldInit <$> fields)) <>
@@ -677,6 +684,7 @@ ppResolvedMessage m =
     indent 17 (vcatPrefix1 (text "  ") (text ", ") (ppFieldAppend "x" "y" <$> fields)) <>
     text "}" <$$>
     text "" <$$>
+
     hcat (ppFieldLens (pretty nm) <$> fields) <>
     text "instance HPB.HasMessageRep" <+> pretty nm <+> text "where" <$$>
     text "  messageRep" <$$>

--- a/src/Data/HPB.hs
+++ b/src/Data/HPB.hs
@@ -70,7 +70,7 @@ module Data.HPB (
   , B.ByteString
 
   , Data.Monoid.Monoid(..)
-  , (Data.Monoid.<>)
+  , Data.Semigroup.Semigroup(..)
   , Data.String.fromString
 
   , (Control.Lens.&)
@@ -106,7 +106,8 @@ import qualified Data.HashSet as HSet
 import qualified Data.HashTable.ST.Basic as H
 import Data.Int
 import Data.Maybe
-import Data.Monoid
+import Data.Monoid hiding ( (<>) )
+import Data.Semigroup
 import Data.Sequence as Seq
 import qualified Data.String
 import Data.Text (Text)
@@ -632,7 +633,7 @@ bytesField = lengthDelimField id id
 stringField :: Text -> Required Text -> FieldDef a Text
 stringField = lengthDelimField Text.encodeUtf8 Text.decodeUtf8
 
-messageField :: Monoid m
+messageField :: (Semigroup m, Monoid m)
              => MessageRep m
              -> Text
              -> Bool -- ^ Indicates if the message is required.


### PR DESCRIPTION
Updates to support GHC 8.4+ clients where Monoid instances require a Semigroup instance.